### PR TITLE
fix: array proxy equality mismatch

### DIFF
--- a/packages/core/src/lib/hooks/utilities/use-scrollable-ancestors.svelte.ts
+++ b/packages/core/src/lib/hooks/utilities/use-scrollable-ancestors.svelte.ts
@@ -3,6 +3,10 @@ import {useLazyMemo} from '@dnd-kit-svelte/utilities';
 
 const defaultValue: Element[] = [];
 
+function arraysShallowEqual(a: Element[], b: Element[]) {
+	return a.length === b.length && a.every((el, i) => el === b[i]);
+}
+
 export function useScrollableAncestors(nodeFn: () => HTMLElement | null) {
 	const node = $derived(nodeFn());
 	let previousNode = node;
@@ -14,7 +18,8 @@ export function useScrollableAncestors(nodeFn: () => HTMLElement | null) {
 
 		if (
 			previousValue &&
-			previousValue !== defaultValue &&
+			Array.isArray(previousValue) &&
+			!arraysShallowEqual(previousValue, defaultValue) &&
 			node &&
 			previousNode &&
 			node.parentNode === previousNode.parentNode


### PR DESCRIPTION
This PR fixes an issue with array proxies and strict equality comparisons in `useScrollableAncestors`.

The issue:


https://github.com/user-attachments/assets/9658020a-ca83-4d5c-bffe-3f9e8e4a26d4

